### PR TITLE
レモンを絞るカウントダウンの表示を追加

### DIFF
--- a/app/src/main/java/com/example/lemonade/MainActivity.kt
+++ b/app/src/main/java/com/example/lemonade/MainActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.sp
 import com.example.lemonade.ui.theme.LemonadeTheme
 
 class MainActivity : ComponentActivity() {
@@ -54,7 +55,7 @@ class MainActivity : ComponentActivity() {
 @Preview
 @Composable
 fun LemonApp() {
-    var currentStep by remember { mutableStateOf(1) }    //初期値が１に設定された可変のStateオブジェクトをremenberでcurrentstepに常に保持する
+    var currentStep by remember { mutableStateOf(1) } // 初期値が１に設定された可変のStateオブジェクトをrememberでcurrentStepに保持
     var squeezeCount by remember { mutableStateOf(0) }
 
     Scaffold(
@@ -86,7 +87,7 @@ fun LemonApp() {
                         imageResorceId = R.drawable.lemon_tree,
                         onImageClick = {
                             currentStep = 2
-                            squeezeCount = (2..4).random()
+                            squeezeCount = (2..4).random() // ランダムな絞る回数を設定
                         }
                     )
                 }
@@ -97,10 +98,11 @@ fun LemonApp() {
                         imageResorceId = R.drawable.lemon_squeeze,
                         onImageClick = {
                             squeezeCount--
-                            if (squeezeCount == 0) {
+                            if (squeezeCount <= 0) {
                                 currentStep = 3
                             }
-                        }
+                        },
+                        squeezeCount = squeezeCount // squeezeCountを渡す
                     )
                 }
 
@@ -133,16 +135,30 @@ fun LemonTextAndImage(
     textResorcedId: Int,
     imageResorceId: Int,
     onImageClick: () -> Unit,
+    squeezeCount: Int = 0, // squeezeCountを追加
     modifier: Modifier = Modifier
 ) {
     Box(
         modifier = modifier
+
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxSize()
         ) {
+            // 絞る回数を画像の上に表示
+            if (squeezeCount > 0) {
+                Text(
+                    text = "$squeezeCount",
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold
+                    ),
+                )
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+
             Button(
                 onClick = onImageClick,
                 shape = RoundedCornerShape(dimensionResource(R.dimen.button_corner_radius)),


### PR DESCRIPTION
### 概要

- レモンの絞った回数に合わせて数字の表示

### 変更内容

- `squeezeCount = (2..4).random()` でランダムに絞る回数を設定し、`squeezeCount`が0より大きい場合テキストとして数字を表示する            

<img width="237" alt="スクリーンショット 2024-10-02 16 42 17" src="https://github.com/user-attachments/assets/c74133a7-deae-4dad-a8fe-fdebc47dec2d">
