### PR TITLE
完成のダイアログの追加

### DIFF
--- a/app/src/main/java/com/example/lemonade/MainActivity.kt
+++ b/app/src/main/java/com/example/lemonade/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -57,6 +58,7 @@ class MainActivity : ComponentActivity() {
 fun LemonApp() {
     var currentStep by remember { mutableStateOf(1) } // 初期値が１に設定された可変のStateオブジェクトをrememberでcurrentStepに保持
     var squeezeCount by remember { mutableStateOf(0) }
+    var showCompletionDialog by remember { mutableStateOf(false) } // ポップアップ表示フラグ
 
     Scaffold(
         topBar = {
@@ -111,7 +113,7 @@ fun LemonApp() {
                         textResorcedId = R.string.Glassoflemonade,
                         imageResorceId = R.drawable.lemon_drink,
                         onImageClick = {
-                            currentStep = 4
+                            showCompletionDialog = true // 完成ポップアップを表示
                         }
                     )
                 }
@@ -125,6 +127,26 @@ fun LemonApp() {
                         }
                     )
                 }
+            }
+
+            // ポップアップダイアログ
+            if (showCompletionDialog) {
+                AlertDialog(
+                    onDismissRequest = {
+                        showCompletionDialog = false // ポップアップを閉じる
+                        currentStep = 4 // グラスを空に戻す
+                    },
+                    title = { Text(text = "完成！") },
+                    text = { Text(text = "レモネードが完成しました！") },
+                    confirmButton = {
+                        Button(onClick = {
+                            showCompletionDialog = false // ポップアップを閉じる
+                            currentStep = 1 // グラスを空に戻す
+                        }) {
+                            Text("閉じる")
+                        }
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/lemonade/MainActivity.kt
+++ b/app/src/main/java/com/example/lemonade/MainActivity.kt
@@ -134,17 +134,26 @@ fun LemonApp() {
                 AlertDialog(
                     onDismissRequest = {
                         showCompletionDialog = false // ポップアップを閉じる
-                        currentStep = 4 // グラスを空に戻す
+                        currentStep = 4
                     },
                     title = { Text(text = "完成！") },
                     text = { Text(text = "レモネードが完成しました！") },
                     confirmButton = {
                         Button(onClick = {
                             showCompletionDialog = false // ポップアップを閉じる
-                            currentStep = 1 // グラスを空に戻す
+                            currentStep = 4
                         }) {
                             Text("閉じる")
                         }
+                    }
+                )
+            }
+            else if (currentStep == 4) {
+                LemonTextAndImage(
+                    textResorcedId = R.string.Emptyglass,
+                    imageResorceId = R.drawable.lemon_restart,
+                    onImageClick = {
+                        currentStep = 1 // 再スタートする場合の処理
                     }
                 )
             }


### PR DESCRIPTION
### 概要

- レモネードが完成した際に完成のポップアップダイアログで表示する

### 変更内容

- `var showCompletionDialog by remember { mutableStateOf(false) }`で宣言し、レモネードが完成した際に` true`で表示する

### 現状

- 空のグラスが表示されなくなり、最初の画像（レモンの木）が表示されるようになってしまった

### これから実施すること

- ポップアップダイアログを閉じたら空のグラスに遷移するように改修
<img width="227" alt="スクリーンショット 2024-10-02 17 26 50" src="https://github.com/user-attachments/assets/aa8b21a2-5e13-42a3-a53a-4576b96fcf8b">
