### PR TITLE
カウントダウンの文字を大きく表示

### DIFF
--- a/app/src/main/java/com/example/lemonade/MainActivity.kt
+++ b/app/src/main/java/com/example/lemonade/MainActivity.kt
@@ -152,7 +152,7 @@ fun LemonTextAndImage(
                 Text(
                     text = "$squeezeCount",
                     style = MaterialTheme.typography.bodyLarge.copy(
-                        fontSize = 24.sp,
+                        fontSize = 50.sp,
                         fontWeight = FontWeight.Bold
                     ),
                 )


### PR DESCRIPTION
### 概要

- カウントダウンの文字を大きくして見やすいように変更しました

### 変更内容
文字の大きさの設定を`24.sp`から`50.sp`に変更

<img width="218" alt="スクリーンショット 2024-10-04 16 40 01" src="https://github.com/user-attachments/assets/03a62a67-93b6-483c-938e-cdbcb4b77cdb">

