### PR TITLE
ヘッダーの文字を大きくしました

### DIFF
--- a/app/src/main/java/com/example/lemonade/MainActivity.kt
+++ b/app/src/main/java/com/example/lemonade/MainActivity.kt
@@ -65,7 +65,7 @@ fun LemonApp() {
                     Text(
                         text = "Lemonade",
                         fontWeight = FontWeight.Bold,
-                        fontSize = 37.sp,
+                        fontSize = 35.sp,
                     )
                 },
                 colors = TopAppBarDefaults.largeTopAppBarColors(


### PR DESCRIPTION
### 概要

- ヘッダーの文字を大きくするよう変更しました

### 変更内容

- `fontSize = 35.sp,`で指定を行いました

<img width="221" alt="スクリーンショット 2024-10-04 17 18 31" src="https://github.com/user-attachments/assets/7052c123-5283-4631-be5e-d0d12052415f">
